### PR TITLE
🔧: Move pytest flags to cfg file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = '--verbosity=2 --doctest-modules --ignore=docs'
+

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands = black --check .
 [testenv:test]
 description = "Pytest"
 deps = pytest
-commands = pytest --doctest-modules -v --ignore=docs
+commands = pytest
 
 [testenv:docs]
 description = "Sphinx"


### PR DESCRIPTION
This enables consistant behavior when running `pytest` in and out of tox.