### PR TITLE
✅(pytest): Add code coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,13 @@
 requires = ["setuptools >= 40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+
 [tool.pytest.ini_options]
-addopts = '--verbosity=2 --doctest-modules --ignore=docs'
+addopts = '--verbosity=2 --doctest-modules --ignore=docs --cov fizzbuzz'
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands = black --check .
 
 [testenv:test]
 description = "Pytest"
-deps = pytest
+deps = pytest-cov
 commands = pytest
 
 [testenv:docs]


### PR DESCRIPTION
Coverage report will be appended to the end of `pytest`, e.g.:
```
----------- coverage: platform linux, python 3.9.0-final-0 -----------
Name          Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------------
fizzbuzz.py      45     20      4      1    57.14%   28-29, 41-42, 137-142, 147-152, 157-158, 161->163, 163-168
```